### PR TITLE
Allow https for all modules

### DIFF
--- a/library/nxos_command
+++ b/library/nxos_command
@@ -93,7 +93,7 @@ options:
             - Dictates connection protocol to use for NX-API
         required: false
         default: http
-        choices: ['http']
+        choices: ['http', 'https']
         aliases: []
 '''
 
@@ -150,7 +150,8 @@ def main():
     text = module.params['text'] or False
     cmd_type = module.params['type'].lower()
 
-    device = Device(ip=host, username=username, password=password)
+    device = Device(ip=host, username=username, password=password,
+                    protocol=protocol)
 
     if cmd_type == 'show':
         if isinstance(command, list):

--- a/library/nxos_copy
+++ b/library/nxos_copy
@@ -117,7 +117,7 @@ options:
             - Dictates connection protocol to use for NX-API
         required: false
         default: http
-        choices: ['http']
+        choices: ['http', 'https']
         aliases: []
 '''
 
@@ -172,7 +172,8 @@ def main():
     host = socket.gethostbyname(module.params['host'])
     server_pw = module.params['server_pw']
 
-    device = Device(ip=host, username=username, password=password)
+    device = Device(ip=host, username=username, password=password,
+                    protocol=protocol)
     device.set_timeout = 120
 
     local_path = module.params['local_path']

--- a/library/nxos_dir
+++ b/library/nxos_dir
@@ -76,7 +76,7 @@ options:
             - Dictates connection protocol to use for NX-API
         required: false
         default: http
-        choices: ['http']
+        choices: ['http', 'https']
         aliases: []
 '''
 
@@ -122,7 +122,8 @@ def main():
     host = socket.gethostbyname(module.params['host'])
     state = module.params['state']
 
-    device = Device(ip=host, username=username, password=password)
+    device = Device(ip=host, username=username, password=password,
+                    protocol=protocol)
 
     path = module.params['path']
     valid_list = ['bootflash', 'debug', 'log', 'logflash', 'usb1', 'usb2',

--- a/library/nxos_feature
+++ b/library/nxos_feature
@@ -75,7 +75,7 @@ options:
             - Dictates connection protocol to use for NX-API
         required: false
         default: http
-        choices: ['http']
+        choices: ['http', 'https']
         aliases: []
 '''
 
@@ -124,7 +124,8 @@ def main():
     feature = module.params['feature'].lower()
     state = module.params['state'].lower()
 
-    device = Device(ip=host, username=username, password=password)
+    device = Device(ip=host, username=username, password=password,
+                    protocol=protocol)
 
     avail_features = nxapi_lib.get_feature_list(device)
     if feature not in avail_features:

--- a/library/nxos_get_facts
+++ b/library/nxos_get_facts
@@ -68,7 +68,7 @@ options:
             - Dictates connection protocol to use for NX-API
         required: false
         default: http
-        choices: ['http']
+        choices: ['http', 'https']
         aliases: []
 '''
 
@@ -112,7 +112,8 @@ def main():
 
     detail = module.params['detail']
 
-    device = Device(ip=host, username=username, password=password)
+    device = Device(ip=host, username=username, password=password,
+                    protocol=protocol)
 
     facts = nxapi_lib.get_facts(device)
 

--- a/library/nxos_get_interface
+++ b/library/nxos_get_interface
@@ -68,7 +68,7 @@ options:
             - Dictates connection protocol to use for NX-API
         required: false
         default: http
-        choices: ['http']
+        choices: ['http', 'https']
         aliases: []
 '''
 
@@ -108,7 +108,8 @@ def main():
     host = socket.gethostbyname(module.params['host'])
 
     interface = module.params['interface'].lower()
-    device = Device(ip=host, username=username, password=password)
+    device = Device(ip=host, username=username, password=password,
+                    protocol=protocol)
 
     itype = nxapi_lib.get_interface_type(interface)
     if itype != 'ethernet':

--- a/library/nxos_get_neighbors
+++ b/library/nxos_get_neighbors
@@ -110,7 +110,8 @@ def main():
     host = socket.gethostbyname(module.params['host'])
 
     neigh_type = module.params['type'].lower()
-    device = Device(ip=host, username=username, password=password)
+    device = Device(ip=host, username=username, password=password,
+                    protocol=protocol)
 
     neighbors = nxapi_lib.get_neighbors(device, neigh_type)
 

--- a/library/nxos_hsrp
+++ b/library/nxos_hsrp
@@ -121,7 +121,7 @@ options:
             - Dictates connection protocol to use for NX-API
         required: false
         default: http
-        choices: ['http']
+        choices: ['http', 'https']
         aliases: []
 '''
 
@@ -184,7 +184,8 @@ def main():
     auth_type = module.params['auth_type']
     auth_string = module.params['auth_string']
 
-    device = Device(ip=host, username=username, password=password)
+    device = Device(ip=host, username=username, password=password,
+                    protocol=protocol)
 
     interface = interface.lower()
     args = dict(group=group, version=version, priority=priority,

--- a/library/nxos_interface
+++ b/library/nxos_interface
@@ -116,7 +116,7 @@ options:
             - Dictates connection protocol to use for NX-API
         required: false
         default: http
-        choices: ['http']
+        choices: ['http', 'https']
         aliases: []
 '''
 
@@ -189,7 +189,8 @@ def main():
     mode = module.params['mode']
     state = module.params['state']
 
-    device = Device(ip=host, username=username, password=password)
+    device = Device(ip=host, username=username, password=password,
+                    protocol=protocol)
 
     changed = False
 

--- a/library/nxos_ipv4_interface
+++ b/library/nxos_ipv4_interface
@@ -92,7 +92,7 @@ options:
             - Dictates connection protocol to use for NX-API
         required: false
         default: http
-        choices: ['http']
+        choices: ['http', 'https']
         aliases: []
 '''
 
@@ -151,7 +151,8 @@ def main():
     interface = module.params['interface']
     state = module.params['state']
 
-    device = Device(ip=host, username=username, password=password)
+    device = Device(ip=host, username=username, password=password,
+                    protocol=protocol)
 
     changed = False
 

--- a/library/nxos_mtu
+++ b/library/nxos_mtu
@@ -90,7 +90,7 @@ options:
             - Dictates connection protocol to use for NX-API
         required: false
         default: http
-        choices: ['http']
+        choices: ['http', 'https']
         aliases: []
 '''
 
@@ -148,7 +148,8 @@ def main():
 
     state = module.params['state']
 
-    device = Device(ip=host, username=username, password=password)
+    device = Device(ip=host, username=username, password=password,
+                    protocol=protocol)
 
     args = dict(mtu=mtu, sysmtu=sysmtu)
     proposed = {}

--- a/library/nxos_ping
+++ b/library/nxos_ping
@@ -89,7 +89,7 @@ options:
             - Dictates connection protocol to use for NX-API
         required: false
         default: http
-        choices: ['http']
+        choices: ['http', 'https']
         aliases: []
 '''
 
@@ -178,7 +178,8 @@ def main():
     vrf = module.params['vrf']
     source = module.params['source']
 
-    device = Device(ip=host, username=username, password=password)
+    device = Device(ip=host, username=username, password=password,
+                    protocol=protocol)
 
     OPTIONS = {
         'vrf': vrf,

--- a/library/nxos_portchannel
+++ b/library/nxos_portchannel
@@ -99,7 +99,7 @@ options:
             - Dictates connection protocol to use for NX-API
         required: false
         default: http
-        choices: ['http']
+        choices: ['http', 'https']
         aliases: []
 '''
 EXAMPLES = '''
@@ -164,7 +164,8 @@ def main():
 
     state = module.params['state']
 
-    device = Device(ip=host, username=username, password=password)
+    device = Device(ip=host, username=username, password=password,
+                    protocol=protocol)
     if mode in ['active', 'passive']:
         if not nxapi_lib.feature_enabled(device, 'lacp'):
             module.fail_json(msg='LACP feature needs to be enabled first')

--- a/library/nxos_save_config
+++ b/library/nxos_save_config
@@ -68,7 +68,7 @@ options:
             - Dictates connection protocol to use for NX-API
         required: false
         default: http
-        choices: ['http']
+        choices: ['http', 'https']
         aliases: []
 '''
 
@@ -111,7 +111,8 @@ def main():
 
     path = module.params['path']
 
-    device = Device(ip=host, username=username, password=password)
+    device = Device(ip=host, username=username, password=password,
+                    protocol=protocol)
 
     if path != 'startup-config':
         if ':' not in path:

--- a/library/nxos_switchport
+++ b/library/nxos_switchport
@@ -111,7 +111,7 @@ options:
             - Dictates connection protocol to use for NX-API
         required: false
         default: http
-        choices: ['http']
+        choices: ['http', 'https']
         aliases: []
 '''
 EXAMPLES = '''
@@ -170,7 +170,8 @@ def main():
     trunk_vlans = module.params['trunk_vlans']
     native_vlan = module.params['native_vlan']
 
-    device = Device(ip=host, username=username, password=password)
+    device = Device(ip=host, username=username, password=password,
+                    protocol=protocol)
 
     args = dict(interface=interface, mode=mode, access_vlan=access_vlan,
                 native_vlan=native_vlan, trunk_vlans=trunk_vlans)

--- a/library/nxos_udld
+++ b/library/nxos_udld
@@ -92,7 +92,7 @@ options:
             - Dictates connection protocol to use for NX-API
         required: false
         default: http
-        choices: ['http']
+        choices: ['http', 'https']
         aliases: []
 '''
 EXAMPLES = '''
@@ -142,7 +142,8 @@ def main():
     reset = module.params['reset']
     state = module.params['state']
 
-    device = Device(ip=host, username=username, password=password)
+    device = Device(ip=host, username=username, password=password,
+                    protocol=protocol)
 
     args = dict(aggressive=aggressive, msg_time=msg_time, reset=reset)
     '''

--- a/library/nxos_udld_interface
+++ b/library/nxos_udld_interface
@@ -83,7 +83,7 @@ options:
             - Dictates connection protocol to use for NX-API
         required: false
         default: http
-        choices: ['http']
+        choices: ['http', 'https']
         aliases: []
 '''
 EXAMPLES = '''
@@ -135,7 +135,8 @@ def main():
     mode = module.params['mode']
     state = module.params['state']
 
-    device = Device(ip=host, username=username, password=password)
+    device = Device(ip=host, username=username, password=password,
+                    protocol=protocol)
 
     proposed = dict(mode=mode)
     if not nxapi_lib.feature_enabled(device, 'udld'):

--- a/library/nxos_vlan
+++ b/library/nxos_vlan
@@ -94,7 +94,7 @@ options:
             - Dictates connection protocol to use for NX-API
         required: false
         default: http
-        choices: ['http']
+        choices: ['http', 'https']
         aliases: []
 '''
 EXAMPLES = '''
@@ -160,7 +160,8 @@ def main():
     admin_state = module.params['admin_state']
     state = module.params['state']
 
-    device = Device(ip=host, username=username, password=password)
+    device = Device(ip=host, username=username, password=password,
+                    protocol=protocol)
 
     changed = False
     proposed = dict(vlan_id=vlan_id, name=name, vlan_state=vlan_state,

--- a/library/nxos_vpc
+++ b/library/nxos_vpc
@@ -135,7 +135,7 @@ options:
             - Dictates connection protocol to use for NX-API
         required: false
         default: http
-        choices: ['http']
+        choices: ['http', 'https']
         aliases: []
 '''
 EXAMPLES = '''
@@ -198,7 +198,8 @@ def main():
     delay_restore = module.params['delay_restore']
     state = module.params['state']
 
-    device = Device(ip=host, username=username, password=password)
+    device = Device(ip=host, username=username, password=password,
+                    protocol=protocol)
 
     changed = False
 

--- a/library/nxos_vpc_interface
+++ b/library/nxos_vpc_interface
@@ -93,7 +93,7 @@ options:
             - Dictates connection protocol to use for NX-API
         required: false
         default: http
-        choices: ['http']
+        choices: ['http', 'https']
         aliases: []
 '''
 EXAMPLES = '''
@@ -144,7 +144,8 @@ def main():
     peer_link = module.params['peer_link']
     state = module.params['state']
 
-    device = Device(ip=host, username=username, password=password)
+    device = Device(ip=host, username=username, password=password,
+                    protocol=protocol)
     device.open()
 
     changed = False

--- a/library/nxos_vrf
+++ b/library/nxos_vrf
@@ -87,7 +87,7 @@ options:
             - Dictates connection protocol to use for NX-API
         required: false
         default: http
-        choices: ['http']
+        choices: ['http', 'https']
         aliases: []
 '''
 EXAMPLES = '''
@@ -135,7 +135,8 @@ def main():
     description = module.params['description']
     state = module.params['state']
 
-    device = Device(ip=host, username=username, password=password)
+    device = Device(ip=host, username=username, password=password,
+                    protocol=protocol)
 
     changed = False
 

--- a/library/nxos_vrf_interface
+++ b/library/nxos_vrf_interface
@@ -86,7 +86,7 @@ options:
             - Dictates connection protocol to use for NX-API
         required: false
         default: http
-        choices: ['http']
+        choices: ['http', 'https']
         aliases: []
 '''
 EXAMPLES = '''
@@ -132,7 +132,8 @@ def main():
     interface = module.params['interface'].lower()
     state = module.params['state']
 
-    device = Device(ip=host, username=username, password=password)
+    device = Device(ip=host, username=username, password=password,
+                    protocol=protocol)
     changed = False
 
     intf_type = nxapi_lib.get_interface_type(interface)


### PR DESCRIPTION
This adds 'https' to the protocol option for each module, and passes it
through to the Device class.

Depends on: https://github.com/jedelman8/pycsco/pull/2/files
