### PR TITLE
Fixes issue with single digit port channels.

### DIFF
--- a/library/nxos_vpc_interface
+++ b/library/nxos_vpc_interface
@@ -173,14 +173,14 @@ def main():
         if vpc:
             mapping = \
                 nxapi_lib.get_existing_portchannel_to_vpc_mappings(device)
-            if vpc in mapping.keys() and portchannel != mapping[vpc][-2:]:
+            if vpc in mapping.keys() and portchannel != mapping[vpc].strip('Po'):
                 module.fail_json(msg="This vpc is already configured on "
                                  + "another portchannel.  Remove it first "
                                  + "before trying to assign it here. ",
                                  existing_portchannel=mapping[vpc])
 
             for vpcid, existing_pc in mapping.iteritems():
-                if portchannel == existing_pc[-2:] and vpcid != vpc:
+                if portchannel == existing_pc.strip('Po') and vpcid != vpc:
                     module.exit_json(msg="This portchannel already has another"
                                      + " VPC configured.  Remove it first "
                                      + "before assigning this one",


### PR DESCRIPTION
This is the error message I was seeing:
failed: [3064-1] => (item=1) => {"existing_portchannel": "Po1", "failed": true, "item": "1"}
msg: This vpc is already configured on another portchannel.  Remove it first before trying to assign it here.
failed: [3064-1] => (item=2) => {"existing_portchannel": "Po2", "failed": true, "item": "2"}
msg: This vpc is already configured on another portchannel.  Remove it first before trying to assign it here.
failed: [3064-1] => (item=3) => {"existing_portchannel": "Po3", "failed": true, "item": "3"}
msg: This vpc is already configured on another portchannel.  Remove it first before trying to assign it here.

This is what I saw when I debugged.
PortChannels: [u'1', u'2', u'3', u'4', u'5', u'6', u'7', u'8', u'9', u'10', u'11', u'12', u'13', u'14', u'15', u'16', u'17', u'18', u'19', u'20', u'21', u'22', u'33', u'999']
PC to VPC map: {'20': 'Po20', '21': 'Po21', '22': 'Po22', '1': 'Po1', '3': 'Po3', '2': 'Po2', '5': 'Po5', '4': 'Po4', '7': 'Po7', '6': 'Po6', '9': 'Po9', '8': 'Po8', '11': 'Po11', '10': 'Po10', '13': 'Po13', '12': 'Po12', '15': 'Po15', '14': 'Po14', '17': 'Po17', '16': 'Po16', '19': 'Po19', '18': 'Po18'}
VPC map keys: ['20', '21', '22', '1', '3', '2', '5', '4', '7', '6', '9', '8', '11', '10', '13', '12', '15', '14', '17', '16', '19', '18']
VPC map PC: o1

Referencing the modiified copy of the module on subsequent runs resulted in the task returning 'ok'.
