### PR TITLE
Support vlan mode (ce or fabricpath) setting in nxos_vlan module

### DIFF
--- a/library/nxos_vlan
+++ b/library/nxos_vlan
@@ -67,6 +67,14 @@ options:
         default: present
         choices: ['present','absent']
         aliases: []
+    mode:
+        description:
+            - Set VLAN mode to fabricpath or classical ethernet. Requires that
+              feature-set fabricpath is installed in the switch.
+        required: false
+        default: null
+        choices: ['ce', 'fabricpath']
+        aliases: []
     host:
         description:
             - IP Address or hostname (resolvable by Ansible control host)
@@ -140,6 +148,7 @@ def main():
             name=dict(default=None),
             vlan_state=dict(choices=['active', 'suspend'], default='active'),
             state=dict(choices=['present', 'absent'], default='present'),
+            mode=dict(choices=['ce', 'fabricpath'], default=None),
             admin_state=dict(choices=['up', 'down'], default='up'),
             protocol=dict(choices=['http', 'https'], default='http'),
             host=dict(required=True),
@@ -160,13 +169,14 @@ def main():
     vlan_state = module.params['vlan_state']
     admin_state = module.params['admin_state']
     state = module.params['state']
+    mode = module.params['mode']
 
     device = Device(ip=host, username=username, password=password,
                     protocol=protocol)
 
     changed = False
     proposed = dict(vlan_id=vlan_id, name=name, vlan_state=vlan_state,
-                    admin_state=admin_state)
+                    admin_state=admin_state, mode=mode)
 
     proposed_vlans_list = nxapi_lib.vlan_range_to_list(vlan_id)
     proposed_vlans_list.sort()
@@ -222,6 +232,7 @@ def main():
             proposed = dict(vlan_id=vlan,
                             vlan_state=vlan_state,
                             admin_state=admin_state,
+                            mode=mode,
                             name=name)
             delta = set(proposed.iteritems()).difference(existing.iteritems())
             if delta:
@@ -239,7 +250,8 @@ def main():
         final_existing[vlan] = existing
         final_proposed[vlan] = dict(vlan_id=vlan,
                                     vlan_state=vlan_state,
-                                    admin_state=admin_state)
+                                    admin_state=admin_state,
+                                    mode=mode)
 
     if final_commands:
         if module.check_mode:
@@ -258,6 +270,7 @@ def main():
     results['state'] = state
     results['commands'] = final_commands
     results['changed'] = changed
+    results['msg'] = "vlan_id " + vlan_id + " state == " + state
 
     module.exit_json(**results)
 


### PR DESCRIPTION
Adding support to set vlan mode to classical ethernet or fabricpath.
Adding 'msg' key to results dict giving the current state of the vlan.

If `mode` key is not given in playbook everything works as before, else set vlan mode to ce or fabricpath.

The `msg` key in results is used to display which vlan was created in Tower when it's assigned dynamically from a vlan pool during the playbook run.
