### PR TITLE
Tcp port support

### DIFF
--- a/library/nxos_command.py
+++ b/library/nxos_command.py
@@ -80,6 +80,13 @@ options:
         default: null
         choices: []
         aliases: []
+    port:
+        description:
+            - TCP port to use for communication with switch
+        required: false
+        default: null
+        choices: []
+        aliases: []
     username:
         description:
             - Username used to login to the switch
@@ -172,7 +179,7 @@ def parsed_data_from_device(device, command, module, text):
     try:
         data = device.show(command, text=text)
     except CLIError as clie:
-        module.fail_json(msg='Error sending {}'.format(command),
+        module.fail_json(msg='Error sending {0}'.format(command),
                          error=str(clie))
 
     data_dict = xmltodict.parse(data[1])
@@ -186,7 +193,7 @@ def send_config_command(device, command, module):
     try:
         data = device.config(command)
     except CLIError as clie:
-        module.fail_json(msg='Error sending {}'.format(command),
+        module.fail_json(msg='Error sending {0}'.format(command),
                          error=str(clie))
 
     data_dict = xmltodict.parse(data[1])
@@ -225,6 +232,7 @@ def main():
             text=dict(choices=BOOLEANS, type='bool'),
             type=dict(choices=['show', 'config'], required=True),
             protocol=dict(choices=['http', 'https'], default='http'),
+            port=dict(required=False, type='int', default=None),
             host=dict(required=True),
             username=dict(type='str'),
             password=dict(type='str')
@@ -240,6 +248,7 @@ def main():
     username = module.params['username'] or auth.username
     password = module.params['password'] or auth.password
     protocol = module.params['protocol']
+    port = module.params['port']
     host = socket.gethostbyname(module.params['host'])
 
     command = module.params['command']
@@ -248,7 +257,7 @@ def main():
     cmd_type = module.params['type'].lower()
 
     device = Device(ip=host, username=username, password=password,
-                    protocol=protocol)
+                    protocol=protocol, port=port)
 
     changed = False
     cmds = ''

--- a/library/nxos_feature.py
+++ b/library/nxos_feature.py
@@ -56,6 +56,13 @@ options:
         default: null
         choices: []
         aliases: []
+    port:
+        description:
+            - TCP port to use for communication with switch
+        required: false
+        default: null
+        choices: []
+        aliases: []
     username:
         description:
             - Username used to login to the switch
@@ -163,7 +170,7 @@ def temp_parsed_data_from_device(device, command):
         data = device.show(command, text=True)
     except:
         module.fail_json(
-            msg='Error sending {}'.format(command),
+            msg='Error sending {0}'.format(command),
             error=str(clie))
 
     data_dict = xmltodict.parse(data[1])
@@ -220,6 +227,7 @@ def main():
             feature=dict(type='str', required=True),
             state=dict(choices=['enabled', 'disabled'], required=True),
             protocol=dict(choices=['http', 'https'], default='http'),
+            port=dict(required=False, type='int', default=None),
             host=dict(required=True),
             username=dict(type='str'),
             password=dict(type='str'),
@@ -233,13 +241,14 @@ def main():
     username = module.params['username'] or auth.username
     password = module.params['password'] or auth.password
     protocol = module.params['protocol']
+    port = module.params['port']
     host = socket.gethostbyname(module.params['host'])
 
     feature = module.params['feature'].lower()
     state = module.params['state'].lower()
 
     device = Device(ip=host, username=username, password=password,
-                    protocol=protocol)
+                    protocol=protocol, port=port)
 
     available_features = get_available_features(device, feature, module)
 

--- a/library/nxos_get_facts.py
+++ b/library/nxos_get_facts.py
@@ -123,7 +123,7 @@ def parsed_data_from_device(device, command, module):
     try:
         data = device.show(command)
     except CLIError as clie:
-        module.fail_json(msg='Error sending {}'.format(command),
+        module.fail_json(msg='Error sending {0}'.format(command),
                          error=str(clie))
 
     data_dict = xmltodict.parse(data[1])

--- a/library/nxos_get_facts.py
+++ b/library/nxos_get_facts.py
@@ -49,6 +49,13 @@ options:
         default: null
         choices: []
         aliases: []
+    port:
+        description:
+            - TCP port to use for communication with switch
+        required: false
+        default: null
+        choices: []
+        aliases: []
     username:
         description:
             - Username used to login to the switch
@@ -272,6 +279,7 @@ def main():
         argument_spec=dict(
             detail=dict(choices=BOOLEANS, type='bool'),
             protocol=dict(choices=['http', 'https'], default='http'),
+            port=dict(required=False, type='int', default=None),
             host=dict(required=True),
             username=dict(type='str'),
             password=dict(type='str'),
@@ -285,12 +293,13 @@ def main():
     username = module.params['username'] or auth.username
     password = module.params['password'] or auth.password
     protocol = module.params['protocol']
+    port = module.params['port']
     host = socket.gethostbyname(module.params['host'])
 
     detail = module.params['detail']
 
     device = Device(ip=host, username=username, password=password,
-                    protocol=protocol)
+                    protocol=protocol, port=port)
 
     show_version_command = 'show version'
     interface_command = 'show interface status'

--- a/library/nxos_get_neighbors.py
+++ b/library/nxos_get_neighbors.py
@@ -49,6 +49,13 @@ options:
         default: null
         choices: []
         aliases: []
+    port:
+        description:
+            - TCP port to use for communication with switch
+        required: false
+        default: null
+        choices: []
+        aliases: []
     username:
         description:
             - Username used to login to the switch
@@ -109,7 +116,7 @@ def parsed_data_from_device(device, command, module):
     try:
         data = device.show(command)
     except CLIError as clie:
-        module.fail_json(msg='Error sending {}'.format(command),
+        module.fail_json(msg='Error sending {0}'.format(command),
                          error=str(clie))
 
     data_dict = xmltodict.parse(data[1])
@@ -184,6 +191,7 @@ def main():
         argument_spec=dict(
             type=dict(choices=['cdp', 'lldp'], required=True),
             protocol=dict(choices=['http', 'https'], default='http'),
+            port=dict(required=False, type='int', default=None),
             host=dict(required=True),
             username=dict(type='str'),
             password=dict(type='str'),
@@ -198,11 +206,12 @@ def main():
     username = module.params['username'] or auth.username
     password = module.params['password'] or auth.password
     protocol = module.params['protocol']
+    port = module.params['port']
     host = socket.gethostbyname(module.params['host'])
 
     neighbor_type = module.params['type'].lower()
     device = Device(ip=host, username=username, password=password,
-                    protocol=protocol)
+                    protocol=protocol, port=port)
 
     if neighbor_type == 'lldp':
         neighbors = get_lldp_neighbors(device, module)

--- a/library/nxos_save_config.py
+++ b/library/nxos_save_config.py
@@ -53,6 +53,13 @@ options:
         default: null
         choices: []
         aliases: []
+    port:
+        description:
+            - TCP port to use for communication with switch
+        required: false
+        default: null
+        choices: []
+        aliases: []
     username:
         description:
             - Username used to login to the switch
@@ -119,7 +126,7 @@ def parsed_data_from_device(device, command, module):
     try:
         data = device.show(command, text=True)
     except CLIError as clie:
-        module.fail_json(msg='Error sending {}'.format(command),
+        module.fail_json(msg='Error sending {0}'.format(command),
                          error=str(clie))
 
     try:
@@ -157,6 +164,7 @@ def main():
         argument_spec=dict(
             path=dict(default='startup-config'),
             protocol=dict(choices=['http', 'https'], default='http'),
+            port=dict(required=False, type='int', default=None),
             host=dict(required=True),
             username=dict(type='str'),
             password=dict(type='str'),
@@ -170,12 +178,13 @@ def main():
     username = module.params['username'] or auth.username
     password = module.params['password'] or auth.password
     protocol = module.params['protocol']
+    port= module.params['port']
     host = socket.gethostbyname(module.params['host'])
 
     path = module.params['path']
 
     device = Device(ip=host, username=username, password=password,
-                    protocol=protocol)
+                    protocol=protocol, port=port)
 
     if path != 'startup-config':
         if ':' not in path:

--- a/library/nxos_switchport.py
+++ b/library/nxos_switchport.py
@@ -326,7 +326,7 @@ def remove_switchport_config_commands(interface, existing, proposed):
     if mode == 'access':
         av_check = existing.get('access_vlan') == proposed.get('access_vlan')
         if av_check:
-            command = 'no switchport access vlan {}'.format(
+            command = 'no switchport access vlan {0}'.format(
                 existing.get('access_vlan'))
             commands.append(command)
     elif mode == 'trunk':
@@ -338,13 +338,13 @@ def remove_switchport_config_commands(interface, existing, proposed):
                     vlans_to_remove = True
                     break
             if vlans_to_remove:
-                command = 'switchport trunk allowed vlan remove {}'.format(
+                command = 'switchport trunk allowed vlan remove {0}'.format(
                     proposed.get('trunk_vlans'))
                 commands.append(command)
         native_check = existing.get(
             'native_vlan') == proposed.get('native_vlan')
         if native_check and proposed.get('native_vlan'):
-            command = 'no switchport trunk native vlan {}'.format(
+            command = 'no switchport trunk native vlan {0}'.format(
                 existing.get('native_vlan'))
             commands.append(command)
     if commands:
@@ -372,7 +372,7 @@ def get_switchport_config_commands(interface, existing, proposed):
     if proposed_mode == 'access':
         av_check = existing.get('access_vlan') == proposed.get('access_vlan')
         if not av_check:
-            command = 'switchport access vlan {}'.format(
+            command = 'switchport access vlan {0}'.format(
                 proposed.get('access_vlan'))
             commands.append(command)
     elif proposed_mode == 'trunk':
@@ -384,13 +384,13 @@ def get_switchport_config_commands(interface, existing, proposed):
                     vlans_to_add = True
                     break
             if vlans_to_add:
-                command = 'switchport trunk allowed vlan add {}'.format(proposed.get('trunk_vlans'))
+                command = 'switchport trunk allowed vlan add {0}'.format(proposed.get('trunk_vlans'))
                 commands.append(command)
 
         native_check = existing.get(
             'native_vlan') == proposed.get('native_vlan')
         if not native_check and proposed.get('native_vlan'):
-            command = 'switchport trunk native vlan {}'.format(
+            command = 'switchport trunk native vlan {0}'.format(
                 proposed.get('native_vlan'))
             commands.append(command)
     if commands:
@@ -502,7 +502,7 @@ def parsed_data_from_device(device, command, module):
     try:
         data = device.show(command)
     except CLIError as clie:
-        module.fail_json(msg='Error sending {}'.format(command),
+        module.fail_json(msg='Error sending {0}'.format(command),
                          error=str(clie))
 
     data_dict = xmltodict.parse(data[1])

--- a/library/nxos_switchport.py
+++ b/library/nxos_switchport.py
@@ -90,6 +90,13 @@ options:
         default: null
         choices: []
         aliases: []
+    port:
+        description:
+            - TCP port to use for communication with switch
+        required: false
+        default: null
+        choices: []
+        aliases: []
     username:
         description:
             - Username used to login to the switch
@@ -541,6 +548,7 @@ def main():
             state=dict(choices=['absent', 'present', 'unconfigured'],
                        default='present'),
             protocol=dict(choices=['http', 'https'], default='http'),
+            port=dict(required=False, type='int', default=None),
             host=dict(required=True),
             username=dict(required=False),
             password=dict(required=False),
@@ -557,6 +565,7 @@ def main():
     username = module.params['username'] or auth.username
     password = module.params['password'] or auth.password
     protocol = module.params['protocol']
+    port = module.params['port']
     host = socket.gethostbyname(module.params['host'])
 
     interface = module.params['interface']
@@ -567,7 +576,7 @@ def main():
     native_vlan = module.params['native_vlan']
 
     device = Device(ip=host, username=username, password=password,
-                    protocol=protocol)
+                    protocol=protocol, port=port)
 
     args = dict(interface=interface, mode=mode, access_vlan=access_vlan,
                 native_vlan=native_vlan, trunk_vlans=trunk_vlans)

--- a/library/nxos_vlan.py
+++ b/library/nxos_vlan.py
@@ -238,10 +238,10 @@ def build_commands(vlans, state):
     commands = []
     for vlan in vlans:
         if state == 'present':
-            command = 'vlan {}'.format(vlan)
+            command = 'vlan {0}'.format(vlan)
             commands.append(command)
         elif state == 'absent':
-            command = 'no vlan {}'.format(vlan)
+            command = 'no vlan {0}'.format(vlan)
             commands.append(command)
     return commands
 
@@ -361,7 +361,7 @@ def parsed_data_from_device(device, command, module):
     try:
         data = device.show(command)
     except CLIError as clie:
-        module.fail_json(msg='Error sending {}'.format(command),
+        module.fail_json(msg='Error sending {0}'.format(command),
                          error=str(clie))
 
     data_dict = xmltodict.parse(data[1])

--- a/library/nxos_vlan.py
+++ b/library/nxos_vlan.py
@@ -84,6 +84,13 @@ options:
         default: null
         choices: []
         aliases: []
+    port:
+        description:
+            - TCP port to use for communication with switch
+        required: false
+        default: null
+        choices: []
+        aliases: []
     username:
         description:
             - Username used to login to the switch
@@ -246,7 +253,7 @@ def get_vlan_config_commands(vlan, vid):
     reverse_value_map = {
         "admin_state": {
             "down": "shutdown",
-            "up": "noshutdown"
+            "up": "no shutdown"
         }
     }
 
@@ -399,6 +406,7 @@ def main():
             state=dict(choices=['present', 'absent'], default='present'),
             admin_state=dict(choices=['up', 'down'], required=False),
             protocol=dict(choices=['http', 'https'], default='http'),
+            port=dict(required=False, type='int', default=None),
             host=dict(required=True),
             username=dict(type='str'),
             password=dict(type='str'),
@@ -415,6 +423,7 @@ def main():
     username = module.params['username'] or auth.username
     password = module.params['password'] or auth.password
     protocol = module.params['protocol']
+    port = module.params['port']
     host = socket.gethostbyname(module.params['host'])
 
     vlan_range = module.params['vlan_range']
@@ -425,7 +434,7 @@ def main():
     state = module.params['state']
 
     device = Device(ip=host, username=username, password=password,
-                    protocol=protocol)
+                    protocol=protocol, port=port)
 
     changed = False
 


### PR DESCRIPTION
This PR adds a new argument `port` to all existing refactored .py modules in the modules-no-pycsco-utils branch. The PR depends on support for the `port` argument in the Device() class in pycsco, see https://github.com/jedelman8/pycsco/pull/23.

Additionally this PR changes all unnumbered string format field names to numbered for Python 2.6 support.

Lastly there is a small bug fix in the nxos_vlan.py module where the module would issue a `noshutdown` command instead of `no shutdown` to the switch when changing the mode from absent to present.
