### PR TITLE
Disabled logging for device password fields.

### DIFF
--- a/library/nxos_aaa_server
+++ b/library/nxos_aaa_server
@@ -169,7 +169,7 @@ def main():
                        default='present'),
             host=dict(required=True),
             username=dict(),
-            password=dict(),
+            password=dict(no_log=True),
             protocol=dict(choices=['http', 'https'],
                           default='http')
         ),

--- a/library/nxos_aaa_server_host
+++ b/library/nxos_aaa_server_host
@@ -178,7 +178,7 @@ def main():
                        default='present'),
             host=dict(required=True),
             username=dict(),
-            password=dict(),
+            password=dict(no_log=True),
             protocol=dict(choices=['http', 'https'],
                           default='http')
         ),

--- a/library/nxos_acl
+++ b/library/nxos_acl
@@ -326,7 +326,7 @@ def main():
             protocol=dict(choices=['http', 'https'], default='http'),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         supports_check_mode=True
     )

--- a/library/nxos_acl_interface
+++ b/library/nxos_acl_interface
@@ -123,7 +123,7 @@ def main():
             protocol=dict(choices=['http', 'https'], default='http'),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         supports_check_mode=True
     )

--- a/library/nxos_command.py
+++ b/library/nxos_command.py
@@ -235,7 +235,7 @@ def main():
             port=dict(required=False, type='int', default=None),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str')
+            password=dict(no_log=True, type='str')
         ),
         required_one_of=[['command', 'command_list']],
         mutually_exclusive=[['command', 'command_list']],

--- a/library/nxos_copy
+++ b/library/nxos_copy
@@ -161,7 +161,7 @@ def main():
             protocol=dict(choices=['http', 'https'], default='http'),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         supports_check_mode=False
     )

--- a/library/nxos_dir
+++ b/library/nxos_dir
@@ -110,7 +110,7 @@ def main():
             protocol=dict(choices=['http', 'https'], default='http'),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
             state=dict(options=['present', 'absent'], required=True)
         ),
         supports_check_mode=False

--- a/library/nxos_feature.py
+++ b/library/nxos_feature.py
@@ -230,7 +230,7 @@ def main():
             port=dict(required=False, type='int', default=None),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         supports_check_mode=True
     )

--- a/library/nxos_file_copy
+++ b/library/nxos_file_copy
@@ -108,7 +108,7 @@ def main():
             dest_file=dict(),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
             protocol=dict(default='http', choices=['http', 'https'])
         ),
         supports_check_mode=False

--- a/library/nxos_get_facts.py
+++ b/library/nxos_get_facts.py
@@ -249,7 +249,7 @@ def main():
             port=dict(required=False, type='int', default=None),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         supports_check_mode=False
     )

--- a/library/nxos_get_interface
+++ b/library/nxos_get_interface
@@ -97,7 +97,7 @@ def main():
             protocol=dict(choices=['http', 'https'], default='http'),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         supports_check_mode=False
     )

--- a/library/nxos_get_ipv4_interface
+++ b/library/nxos_get_ipv4_interface
@@ -97,7 +97,7 @@ def main():
             protocol=dict(choices=['http', 'https'], default='http'),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         supports_check_mode=False
     )

--- a/library/nxos_get_neighbors.py
+++ b/library/nxos_get_neighbors.py
@@ -194,7 +194,7 @@ def main():
             port=dict(required=False, type='int', default=None),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         supports_check_mode=False
     )

--- a/library/nxos_hsrp
+++ b/library/nxos_hsrp
@@ -164,7 +164,7 @@ def main():
             protocol=dict(choices=['http', 'https'], default='http'),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         supports_check_mode=True
     )

--- a/library/nxos_igmp
+++ b/library/nxos_igmp
@@ -131,7 +131,7 @@ def main():
             restart=dict(choices=BOOLEANS, type='bool'),
             host=dict(required=True),
             username=dict(),
-            password=dict(),
+            password=dict(no_log=True),
             state=dict(choices=['present', 'default'], default='present'),
             protocol=dict(choices=['http', 'https'],
                           default='http')

--- a/library/nxos_igmp_interface
+++ b/library/nxos_igmp_interface
@@ -145,7 +145,7 @@ def main():
             oif_source=dict(),
             host=dict(required=True),
             username=dict(),
-            password=dict(),
+            password=dict(no_log=True),
             state=dict(choices=['present', 'absent', 'default'],
                        default='present'),
             protocol=dict(choices=['http', 'https'],

--- a/library/nxos_igmp_snooping
+++ b/library/nxos_igmp_snooping
@@ -158,7 +158,7 @@ def main():
             protocol=dict(choices=['http', 'https'], default='http'),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         supports_check_mode=True
     )

--- a/library/nxos_install_config
+++ b/library/nxos_install_config
@@ -143,7 +143,7 @@ def main():
             commit_changes=dict(choices=BOOLEANS),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
             protocol=dict(default='http', choices=['http', 'https'])
         ),
         required_one_of=[['source_config', 'current_cfg_file']],

--- a/library/nxos_interface.py
+++ b/library/nxos_interface.py
@@ -702,7 +702,7 @@ def main():
             port=dict(required=False, type='int', default=None),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         supports_check_mode=True
     )

--- a/library/nxos_ipv4_interface
+++ b/library/nxos_ipv4_interface
@@ -130,7 +130,7 @@ def main():
             protocol=dict(choices=['http', 'https'], default='http'),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         supports_check_mode=True
     )

--- a/library/nxos_mtu
+++ b/library/nxos_mtu
@@ -131,7 +131,7 @@ def main():
             protocol=dict(choices=['http', 'https'], default='http'),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         supports_check_mode=True
     )

--- a/library/nxos_ntp
+++ b/library/nxos_ntp
@@ -158,7 +158,7 @@ def main():
                        default='present'),
             host=dict(required=True),
             username=dict(),
-            password=dict(),
+            password=dict(no_log=True),
             protocol=dict(choices=['http', 'https'],
                           default='http')
         ),

--- a/library/nxos_ntp_auth
+++ b/library/nxos_ntp_auth
@@ -144,7 +144,7 @@ def main():
                        default='present'),
             host=dict(required=True),
             username=dict(),
-            password=dict(),
+            password=dict(no_log=True),
             protocol=dict(choices=['http', 'https'],
                           default='http')
         ),

--- a/library/nxos_ntp_options
+++ b/library/nxos_ntp_options
@@ -127,7 +127,7 @@ def main():
                        default='present'),
             host=dict(required=True),
             username=dict(),
-            password=dict(),
+            password=dict(no_log=True),
             protocol=dict(choices=['http', 'https'],
                           default='http')
         ),

--- a/library/nxos_pim_interface
+++ b/library/nxos_pim_interface
@@ -219,7 +219,7 @@ def main():
             neighbor_type=dict(choices=['prefix', 'routemap']),
             host=dict(required=True),
             username=dict(),
-            password=dict(),
+            password=dict(no_log=True),
             state=dict(choices=['present', 'absent', 'default'],
                        default='present'),
             protocol=dict(choices=['http', 'https'],

--- a/library/nxos_ping
+++ b/library/nxos_ping
@@ -163,7 +163,7 @@ def main():
             protocol=dict(choices=['http', 'https'], default='http'),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         supports_check_mode=False
     )

--- a/library/nxos_portchannel
+++ b/library/nxos_portchannel
@@ -142,7 +142,7 @@ def main():
             protocol=dict(choices=['http', 'https'], default='http'),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         supports_check_mode=True
     )

--- a/library/nxos_save_config.py
+++ b/library/nxos_save_config.py
@@ -167,7 +167,7 @@ def main():
             port=dict(required=False, type='int', default=None),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         supports_check_mode=False
     )

--- a/library/nxos_snmp_community
+++ b/library/nxos_snmp_community
@@ -126,7 +126,7 @@ def main():
                        default='present'),
             host=dict(required=True),
             username=dict(),
-            password=dict(),
+            password=dict(no_log=True),
             protocol=dict(choices=['http', 'https'],
                           default='http')
         ),

--- a/library/nxos_snmp_contact
+++ b/library/nxos_snmp_contact
@@ -104,7 +104,7 @@ def main():
                        default='present'),
             host=dict(required=True),
             username=dict(),
-            password=dict(),
+            password=dict(no_log=True),
             protocol=dict(choices=['http', 'https'],
                           default='http')
         ),

--- a/library/nxos_snmp_host
+++ b/library/nxos_snmp_host
@@ -162,7 +162,7 @@ def main():
                        default='present'),
             host=dict(required=True),
             username=dict(),
-            password=dict(),
+            password=dict(no_log=True),
             protocol=dict(choices=['http', 'https'],
                           default='http')
         ),

--- a/library/nxos_snmp_location
+++ b/library/nxos_snmp_location
@@ -104,7 +104,7 @@ def main():
                        default='present'),
             host=dict(required=True),
             username=dict(),
-            password=dict(),
+            password=dict(no_log=True),
             protocol=dict(choices=['http', 'https'],
                           default='http')
         ),

--- a/library/nxos_snmp_traps
+++ b/library/nxos_snmp_traps
@@ -112,7 +112,7 @@ def main():
                        required=True),
             host=dict(required=True),
             username=dict(),
-            password=dict(),
+            password=dict(no_log=True),
             protocol=dict(choices=['http', 'https'],
                           default='http')
         ),

--- a/library/nxos_snmp_user
+++ b/library/nxos_snmp_user
@@ -142,7 +142,7 @@ def main():
                        default='present'),
             host=dict(required=True),
             username=dict(),
-            password=dict(),
+            password=dict(no_log=True),
             protocol=dict(choices=['http', 'https'],
                           default='http')
         ),

--- a/library/nxos_static_routes
+++ b/library/nxos_static_routes
@@ -151,7 +151,7 @@ def main():
                        default='present'),
             host=dict(required=True),
             username=dict(),
-            password=dict(),
+            password=dict(no_log=True),
             protocol=dict(choices=['http', 'https'],
                           default='http')
         ),

--- a/library/nxos_switchport.py
+++ b/library/nxos_switchport.py
@@ -551,7 +551,7 @@ def main():
             port=dict(required=False, type='int', default=None),
             host=dict(required=True),
             username=dict(required=False),
-            password=dict(required=False),
+            password=dict(no_log=True, required=False),
         ),
         mutually_exclusive=[['access_vlan', 'trunk_vlans'],
                             ['access_vlan', 'native_vlan']],

--- a/library/nxos_udld
+++ b/library/nxos_udld
@@ -127,7 +127,7 @@ def main():
             protocol=dict(choices=['http', 'https'], default='http'),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         supports_check_mode=True
     )

--- a/library/nxos_udld_interface
+++ b/library/nxos_udld_interface
@@ -121,7 +121,7 @@ def main():
             protocol=dict(choices=['http', 'https'], default='http'),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         supports_check_mode=True
     )

--- a/library/nxos_vlan
+++ b/library/nxos_vlan
@@ -401,7 +401,7 @@ def main():
             protocol=dict(choices=['http', 'https'], default='http'),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         mutually_exclusive=[['vlan_range', 'name'],
                             ['vlan_id', 'vlan_range']],

--- a/library/nxos_vlan.py
+++ b/library/nxos_vlan.py
@@ -409,7 +409,7 @@ def main():
             port=dict(required=False, type='int', default=None),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         mutually_exclusive=[['vlan_range', 'name'],
                             ['vlan_id', 'vlan_range']],

--- a/library/nxos_vpc
+++ b/library/nxos_vpc
@@ -177,7 +177,7 @@ def main():
             protocol=dict(choices=['http', 'https'], default='http'),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         supports_check_mode=True
     )

--- a/library/nxos_vpc_interface
+++ b/library/nxos_vpc_interface
@@ -129,7 +129,7 @@ def main():
             protocol=dict(choices=['http', 'https'], default='http'),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         supports_check_mode=True
     )

--- a/library/nxos_vrf
+++ b/library/nxos_vrf
@@ -120,7 +120,7 @@ def main():
             protocol=dict(choices=['http', 'https'], default='http'),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         supports_check_mode=True
     )

--- a/library/nxos_vrf_interface
+++ b/library/nxos_vrf_interface
@@ -118,7 +118,7 @@ def main():
             protocol=dict(choices=['http', 'https'], default='http'),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         supports_check_mode=True
     )

--- a/library/nxos_vrrp
+++ b/library/nxos_vrrp
@@ -151,7 +151,7 @@ def main():
             protocol=dict(choices=['http', 'https'], default='http'),
             host=dict(required=True),
             username=dict(type='str'),
-            password=dict(type='str'),
+            password=dict(no_log=True, type='str'),
         ),
         supports_check_mode=True
     )

--- a/library/nxos_vtp
+++ b/library/nxos_vtp
@@ -125,12 +125,12 @@ def main():
         argument_spec=dict(
             domain=dict(type='str'),
             version=dict(type='str'),
-            vtp_password=dict(type='str'),
+            vtp_password=dict(no_log=True, type='str'),
             state=dict(choices=['absent', 'present'],
                        default='present'),
             host=dict(required=True),
             username=dict(),
-            password=dict(),
+            password=dict(no_log=True),
             protocol=dict(choices=['http', 'https'],
                           default='http')
         ),


### PR DESCRIPTION
Using any of these modules with verbose output enabled will show the device passwords in cleartext. With these changes, instead of showing the password in the logs, the value will be replaced with "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER".
